### PR TITLE
fix: apply PR #29 review fixes — POSIX paths, tokens dict, stray quote

### DIFF
--- a/harvest.py
+++ b/harvest.py
@@ -319,9 +319,13 @@ def _vscode_epoch_to_iso(epoch_ms: int | float) -> str:
 
 def _extract_file_path_from_markdown(text: str) -> str:
     """Extract a local file path from VS Code markdown-link tool messages."""
-    m = _re.search(r'file:///([^\s\)\]]+)', text)
+    m = _re.search(r'file://(/[^\s\)\]]+)', text)
     if m:
-        return _url_unquote(m.group(1)).replace("/", _os.sep)
+        path = _url_unquote(m.group(1))
+        # Strip leading slash for Windows drive paths (e.g. /C:/Users/...)
+        if _re.match(r'^/[A-Za-z]:/', path):
+            path = path[1:]
+        return path.replace("/", _os.sep)
     return ""
 
 
@@ -333,8 +337,10 @@ def get_vscode_sessions_for_date(target_date: str) -> list:
       kind=1 → metadata updates (workspace context, timings, model info)
       kind=2 → chat turns (requests with messages, tool invocations, etc.)
 
-    Uses a fast first-line date pre-filter to avoid loading multi-hundred-MB
-    files that can't possibly match the target date.
+    Uses a fast first-line pre-filter: skips files created after the target
+    date (they can't have earlier activity). Files created before are always
+    parsed; the inner loop filters events by date so non-matching turns are
+    skipped cheaply even in large files.
     """
     chat_dir = _get_vscode_chat_dir()
     if not chat_dir:
@@ -360,13 +366,15 @@ def get_vscode_sessions_for_date(target_date: str) -> list:
         except Exception:
             continue
 
-        # A session created on a different date could still have activity
-        # on target_date, but skip files created >7 days before/after as a
-        # heuristic (covers multi-day sessions without loading huge files).
+        # Skip files created after the target date — they can't have activity
+        # on a date before they existed.  Files created *before* target_date
+        # are always parsed because long-lived sessions can span weeks.
+        # The inner loop filters individual events by date, so large files
+        # that don't match still exit quickly.
         try:
             td = datetime.strptime(target_date, "%Y-%m-%d")
             cd = datetime.strptime(creation_date, "%Y-%m-%d")
-            if abs((td - cd).days) > 7:
+            if cd > td:
                 continue
         except Exception:
             pass

--- a/report.py
+++ b/report.py
@@ -1671,7 +1671,8 @@ def _goals_summary(goals: list, session_lookup: dict = None, session_metrics: di
         project      = g.get("project", "")
         goal_date    = g.get("date", "")
         metrics      = _resolve_metrics(project, session_metrics, goal_date)
-        goal_tokens  = metrics.get("tokens", 0)
+        goal_tok_raw = metrics.get("tokens", 0)
+        goal_tokens  = goal_tok_raw.get("total", 0) if isinstance(goal_tok_raw, dict) else goal_tok_raw
         tokens_html  = _fmt_tokens(goal_tokens)
         tokens_cell  = f"""
           <td style="padding:10px 8px;border-bottom:1px solid {C['border']};
@@ -1742,7 +1743,7 @@ def _goals_summary(goals: list, session_lookup: dict = None, session_metrics: di
         label = f"Show {n_extra} more project{'s' if n_extra != 1 else ''}"
         rows += f"""
         <tr>
-          <td colspan="5" style="padding:0;border-bottom:1px solid {C['border']}">">
+          <td colspan="5" style="padding:0;border-bottom:1px solid {C['border']}">>
             <button id="goals-show-more" onclick="toggleExtraGoals({n_extra})"
                     style="width:100%;background:{C['subtle']};border:none;border-top:1px solid {C['border']};
                            padding:8px 16px;font-size:11px;font-weight:600;color:{C['accent']};


### PR DESCRIPTION
- harvest.py: fix file:// regex to preserve leading / on POSIX and strip it only for Windows drive paths (e.g. /C:/Users/...)
- report.py: handle tokens field as dict or int (use .get('total', 0) when dict)
- report.py: remove stray double-quote in colspan td tag