### PR TITLE
fix: cap (not drop) long gaps in active_minutes; raise threshold to 1…

### DIFF
--- a/harvest.py
+++ b/harvest.py
@@ -1471,9 +1471,17 @@ def compute_elapsed_minutes(session_start: str, session_end: str) -> float:
 def compute_active_minutes(messages: list) -> float:
     """Estimate active engagement time from message timestamps.
 
-    Sums intervals between consecutive messages where the gap is under
-    5 minutes.  Longer gaps represent idle time (user away or thinking)
-    and are excluded from the active total.
+    Sums intervals between consecutive messages, capping each interval at
+    10 minutes.  Long gaps are presumed to mix focused thinking/reading with
+    pure idle time (user away from keyboard), so we credit the threshold's
+    worth of work for each long gap rather than dropping it entirely.
+
+    Rationale: in agentic workflows much of the user's wall-clock time is
+    spent reading diffs, watching tools run, or reasoning between prompts.
+    Dropping any gap over 5 minutes — the prior behavior — discarded most
+    of that lived experience and produced a metric that consistently
+    underreported felt engagement.  Capping at the threshold yields a
+    conservative-but-not-zero credit for those intervals.
     """
     timestamps = []
     for m in messages:
@@ -1490,13 +1498,12 @@ def compute_active_minutes(messages: list) -> float:
         return 1.0  # Single message ≈ 1 min engagement
 
     timestamps.sort()
-    ACTIVE_THRESHOLD = 300  # 5 minutes in seconds
+    ACTIVE_THRESHOLD = 600  # 10 minutes in seconds
     active_s = 0.0
 
     for i in range(1, len(timestamps)):
         gap = (timestamps[i] - timestamps[i - 1]).total_seconds()
-        if gap <= ACTIVE_THRESHOLD:
-            active_s += gap
+        active_s += min(gap, ACTIVE_THRESHOLD)
 
     active_s += 30  # buffer for final message processing
     return round(active_s / 60, 1)


### PR DESCRIPTION
…0 min

The active-engagement metric was systematically under-reporting felt time:

  - Any inter-message gap over 5 minutes was DROPPED entirely (contributed

    zero), not capped. So 12 minutes spent reading a diff, thinking, or

    watching the agent work between two messages added nothing.

  - 5 minutes was too tight for agentic workflows where the user often

    spends 5-10 min reading a long response or watching tools run before

    replying.

Both behaviours produced a metric that consistently understated lived

engagement, especially on sessions with long agent runs or deliberate

thinking pauses.

Fix: raise ACTIVE_THRESHOLD from 5 min to 10 min, AND credit min(gap,

threshold) for every interval rather than dropping long ones. Long

gaps get capped (10 min credit) instead of zero.

Real-data impact on this machine: total active_minutes across recent

active days went from 199 min to 829 min (4.2x), much closer to felt

wall-clock engagement.

The downstream multipliers in prompts/analysis.txt (active_minutes x

2-6) are intentionally left unchanged — the maintainer accepts a higher

human-equivalent estimate as a better reflection of actual delivered

value than the research lower-bound calibration would yield.